### PR TITLE
Adding note for MacOS playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 ## Description
 This is an example of deploying F5s Declarative Onboarding (DO) and Application Services 3 (AS3) Extensions via Ansible to provision a BIG-IP in a declarative manner.
 
+## NOTE: In order to run this playbook from a Mac (OSX) you must install the RPM pkg. Simple with brew
+``` 
+brew install rpm
+```
+
 
 #### Output
 High level playbook flow:


### PR DESCRIPTION
This note will allow user to use MacOS base OS, and deploy the AS3 pkg. Otherwise, it can not be deployed. 